### PR TITLE
fix: text file detection in getTree with buffer-based fallback

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -116,7 +116,15 @@ export const getTree = (
         if (stats.size > 512 * 1024) continue;
 
         try {
-          if (!isText(itemPath)) continue;
+          // If isText(itemPath) fails, try checking the file buffer directly as fallback for files without a recognized extension
+          let isTextFile = isText(itemPath);
+          if (!isTextFile) {
+            try {
+              const buffer = readFileSync(itemPath);
+              isTextFile = isText(undefined, buffer);
+            } catch {}
+          }
+          if (!isTextFile) continue;
 
           let fileTokenCount: number;
           const cached = tokenCountCache.get(itemPath);


### PR DESCRIPTION
- Enhance the logic in getTree to check file buffer with isText if initial path-based check fails.
- This ensures better handling of files without extensions or ambiguous types, reducing false negatives when determining text files.